### PR TITLE
Fix for removed env.absurl

### DIFF
--- a/src/webassets/filter/cssrewrite/__init__.py
+++ b/src/webassets/filter/cssrewrite/__init__.py
@@ -125,7 +125,8 @@ class CSSRewrite(CSSUrlRewriter):
                                 or self.env.url.startswith('//'):
                                 replacement = urlparse.urljoin(self.env.url, asset_path)
                             else:
-                                replacement = urlpath.relpathto(self.env.directory, self.output_path, self.env.absurl(asset_path))
+                                abs_asset_path = os.path.join(self.env.directory, asset_path)
+                                replacement = urlpath.relpathto(self.env.directory, self.output_path, abs_asset_path)
                         else:
                             replacement = urlpath.relpathto(self.env.directory, self.output_path, asset_path)
 


### PR DESCRIPTION
absurl was removed from env in commit 974e917. This seems to cover what you were using it for, but YMMV.
