### PR TITLE
Feature/issue 117

### DIFF
--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -270,6 +270,17 @@ class Resolver(object):
 
         return self.search_for_source(item)
 
+    def resolve_source_to_path(self, file_name):
+        """Given ``item`` from a Bundle's contents, this has to
+        return the final value to use, usually an absolute
+        filesystem path. Unlike :meth:`search_for_source` this
+        will only return the first matching path it finds.
+        """
+        source = self.resolve_source(file_name)
+        if isinstance(source, list):
+            return source[0]
+        return source
+
     def resolve_output_to_path(self, target, bundle):
         """Given ``target``, this has to return the absolute
         filesystem path to which the output file of ``bundle``

--- a/src/webassets/external.py
+++ b/src/webassets/external.py
@@ -80,7 +80,8 @@ class ExternalAssets(Container):
         versioned = self.versioned_folder(file_name)
         url = self.env.resolver.resolve_output_to_url(versioned)
         file_path = self.env.resolver.resolve_source(file_name)
-        if not path.exists(file_path):
+        versioned_path = self.env.resolver.resolve_output_to_path(versioned, self)
+        if not path.exists(versioned_path):
             self.write_file(file_path)
         return url
 

--- a/src/webassets/external.py
+++ b/src/webassets/external.py
@@ -79,7 +79,7 @@ class ExternalAssets(Container):
     def url(self, file_name):
         versioned = self.versioned_folder(file_name)
         url = self.env.resolver.resolve_output_to_url(versioned)
-        file_path = self.env.resolver.resolve_source(file_name)
+        file_path = self.env.resolver.resolve_source_to_path(file_name)
         versioned_path = self.env.resolver.resolve_output_to_path(versioned, self)
         if not path.exists(versioned_path):
             self.write_file(file_path)

--- a/src/webassets/filter/cssrewrite/__init__.py
+++ b/src/webassets/filter/cssrewrite/__init__.py
@@ -123,7 +123,7 @@ class CSSRewrite(CSSUrlRewriter):
                             if self._is_abs_url(self.env.url):
                                 replacement = urlparse.urljoin(self.env.url, asset_path)
                             else:
-                                replacement = urlpath.relpathto(self.env.directory, self.output_path, self.env.resolver.resolve_source_to_path(asset_path))
+                                replacement = urlpath.relpathto(self.env.directory, self.output_path, asset_path)
                         else:
                             replacement = urlpath.relpathto(self.env.directory, self.output_path, asset_path)
 

--- a/src/webassets/filter/cssrewrite/__init__.py
+++ b/src/webassets/filter/cssrewrite/__init__.py
@@ -123,7 +123,7 @@ class CSSRewrite(CSSUrlRewriter):
                             if self._is_abs_url(self.env.url):
                                 replacement = urlparse.urljoin(self.env.url, asset_path)
                             else:
-                                replacement = urlpath.relpathto(self.env.directory, self.output_path, self.env.resolver.resolve_source(asset_path))
+                                replacement = urlpath.relpathto(self.env.directory, self.output_path, self.env.resolver.resolve_source_to_path(asset_path))
                         else:
                             replacement = urlpath.relpathto(self.env.directory, self.output_path, asset_path)
 

--- a/src/webassets/version.py
+++ b/src/webassets/version.py
@@ -157,7 +157,7 @@ class HashVersion(Version):
         self.hasher = hash
 
     def determine_file_version(self, file_name, env):
-        hunk = FileHunk(env.resolver.resolve_source(file_name))
+        hunk = FileHunk(env.resolver.resolve_source_to_path(file_name))
         hasher = self.hasher()
         hasher.update(hunk.data())
         return hasher.hexdigest()[:self.length]


### PR DESCRIPTION
I've run into a few problems where you use env.resolver.resolve_source(...). It seems to return a list (with one path) when I set env.load_path. Since each of the places using it expect a single path, they all fail.

According to the docs this can return a single url, a list or even a bundle. I'm not sure of all the potential ways this can happen. I don't know when a bundle could be returned (or what to do with it generically). Obviously for ExternalAssets purposes it would be unexpected. It seems sane to have a way to resolve and just grab the first thing found.
